### PR TITLE
Fixed a docker bug on Windows with autocrlf enabled

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -3,7 +3,7 @@ FROM php:8.2-apache
 
 # Install system dependencies. We want MySQL CLI so we can communicate with container on socket via Docker from outside.
 RUN apt-get update && \
-    apt-get install -y git default-mysql-client
+    apt-get install -y git default-mysql-client dos2unix
 
 # Install PHP extensions.  This is key because REDCap uses MySQLi
 RUN docker-php-ext-install -j$(nproc) mysqli
@@ -20,6 +20,7 @@ RUN echo "sendmail_path = '/usr/bin/mhsendmail --smtp-addr=mailhog:1025'" >> /us
 
 # Set up the entrypoint
 COPY ./docker-entrypoint.sh /docker-entrypoint.sh
+RUN dos2unix /docker-entrypoint.sh # Required when running on Windows with autocrlf enabled
 RUN chmod +x /docker-entrypoint.sh
 
 # Expose port 80 for Apache.


### PR DESCRIPTION
@aldefouw, this is additional change is required for the entrypoint script to work on Windows when git is configured to use autocrlf.