### PR TITLE
Use presence of PLATFORM to swap architecture of app container

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,19 +9,6 @@ The current implementation keeps with the Docker design principles of being:
 
 * **automateable** - requires no manual build steps
 
-# Changes Needed for ARM64 (Apple Silicon, Raspberry Pi, etc.) Host Machines
-You will need set the following in your `env/app.env` file:
-
-```env
-PLATFORM=arm64
-REDCAP_APP_INTERNAL_PORT=8080
-```
-
-Before running the `build` and `up` commands, this needs to be part of the compose configuration:
-```bash
-cp env/app.env ./.env
-```
-
 # How to Use
 
 Update the environment variable files located underneath /env with your preferences.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,19 @@ The current implementation keeps with the Docker design principles of being:
 
 * **automateable** - requires no manual build steps
 
+# Changes Needed for ARM64 (Apple Silicon, Raspberry Pi, etc.) Host Machines
+You will need set the following in your `env/app.env` file:
+
+```env
+PLATFORM=arm64
+REDCAP_APP_INTERNAL_PORT=8080
+```
+
+Before running the `build` and `up` commands, this needs to be part of the compose configuration:
+```bash
+cp env/app.env ./.env
+```
+
 # How to Use
 
 Update the environment variable files located underneath /env with your preferences.
@@ -16,7 +29,6 @@ Update the environment variable files located underneath /env with your preferen
 Update the docker-compose.yml file with the ports you plan on using (if non-standard).
 
 When you are ready, installation is as easy as:
-```
-$ docker-compose build
-$ docker-compose up
+```bash
+docker-compose build && docker-compose up -d
 ```

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -34,8 +34,11 @@ COPY ./docker-entrypoint.sh /docker-entrypoint.sh
 RUN dos2unix /docker-entrypoint.sh # Required when running on Windows with autocrlf enabled
 RUN chmod +x /docker-entrypoint.sh
 
-# Expose port 80 for Apache.
-EXPOSE 80
+# Configure Apache for non-privileged port if necessary
+# NOTE: this CANNOT be done in docker-entrypoint.sh
+RUN sed -i 's/^Listen 80/Listen ${REDCAP_APP_INTERNAL_PORT}/' /etc/apache2/ports.conf && \
+    sed -i 's/:80>/:${REDCAP_APP_INTERNAL_PORT}>/g' /etc/apache2/sites-enabled/*.conf && \
+    sed -i 's/:80>/:${REDCAP_APP_INTERNAL_PORT}>/g' /etc/apache2/sites-available/*.conf
 
 # Mend traceability labels
 LABEL io.mend.image.dockerfile.path=main/app/Dockerfile

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -34,11 +34,11 @@ COPY ./docker-entrypoint.sh /docker-entrypoint.sh
 RUN dos2unix /docker-entrypoint.sh # Required when running on Windows with autocrlf enabled
 RUN chmod +x /docker-entrypoint.sh
 
-# Configure Apache for non-privileged port if necessary
-# NOTE: this CANNOT be done in docker-entrypoint.sh
-RUN sed -i 's/^Listen 80/Listen ${REDCAP_APP_INTERNAL_PORT}/' /etc/apache2/ports.conf && \
-    sed -i 's/:80>/:${REDCAP_APP_INTERNAL_PORT}>/g' /etc/apache2/sites-enabled/*.conf && \
-    sed -i 's/:80>/:${REDCAP_APP_INTERNAL_PORT}>/g' /etc/apache2/sites-available/*.conf
+# Configure Apache for non-privileged ports to accommodate rootless container managers
+# NOTE: this CANNOT be done in docker-entrypoint.sh as failures prevent running
+RUN sed -i 's/^Listen 80/Listen 8080/' /etc/apache2/ports.conf && \
+    sed -i 's/:80>/:8080>/g' /etc/apache2/sites-enabled/*.conf && \
+    sed -i 's/:80>/:8080>/g' /etc/apache2/sites-available/*.conf
 
 # Mend traceability labels
 LABEL io.mend.image.dockerfile.path=main/app/Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    platform: linux/x86_64
+    platform: ${PLATFORM:-linux/x86_64}
     container_name: redcap_docker-app-1
     build: app
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,14 +2,21 @@ services:
   app:
     platform: ${PLATFORM:-linux/x86_64}
     container_name: redcap_docker-app-1
-    build: app
+    build:
+      context: app
+      args:
+        REDCAP_APP_INTERNAL_PORT: ${REDCAP_APP_INTERNAL_PORT:-80}
     ports:
-      - '8080:80'
+      - '8080:${REDCAP_APP_INTERNAL_PORT:-80}'
     environment:
       PHP_EXTENSION_IMAGICK: 1
       TEMPLATE_PHP_INI: production
     depends_on:
       - db
+    env_file:
+      - ./env/app.env
+    expose:
+      - "${REDCAP_APP_INTERNAL_PORT:-80}"
     volumes:
       - ../edocs/:/var/www/html/edocs:Z
       - ./app/azure:/var/www/html/azure:Z

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,18 @@
 services:
   app:
+    # NOTE: platform is set in redcap_cypress_docker's update.sh and run.sh scripts
     platform: ${PLATFORM:-linux/x86_64}
     container_name: redcap_docker-app-1
-    build:
-      context: app
-      args:
-        REDCAP_APP_INTERNAL_PORT: ${REDCAP_APP_INTERNAL_PORT:-80}
+    build: app
     ports:
-      - '8080:${REDCAP_APP_INTERNAL_PORT:-80}'
+      - '8080:8080'
     environment:
       PHP_EXTENSION_IMAGICK: 1
       TEMPLATE_PHP_INI: production
     depends_on:
       - db
-    env_file:
-      - ./env/app.env
     expose:
-      - "${REDCAP_APP_INTERNAL_PORT:-80}"
+      - "8080"
     volumes:
       - ../edocs/:/var/www/html/edocs:Z
       - ./app/azure:/var/www/html/azure:Z

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,5 @@
 services:
   app:
-    # NOTE: platform is set in redcap_cypress_docker's update.sh and run.sh scripts
-    platform: ${PLATFORM:-linux/x86_64}
     container_name: redcap_docker-app-1
     build: app
     ports:

--- a/env/app.env
+++ b/env/app.env
@@ -1,1 +1,5 @@
 # App environment
+# If your system architecture is ARM, set to: linux/arm64
+PLATFORM=
+# Alter this if your OS restricts port 80 (e.g. macos using podman, even if podman is rootful)
+REDCAP_APP_INTERNAL_PORT=

--- a/env/app.env
+++ b/env/app.env
@@ -1,5 +1,1 @@
 # App environment
-# If your system architecture is ARM, set to: linux/arm64
-PLATFORM=
-# Alter this if your OS restricts port 80 (e.g. macos using podman, even if podman is rootful)
-REDCAP_APP_INTERNAL_PORT=


### PR DESCRIPTION
# Pre-flight Checklist
- [x] Have all lines in this PR been reviewed & optimized by a human with appropriate coding skills? 
- [x] Are all the features in this PR tested by a human? 
- [x] Have other features this PR touches also been tested by a human?
- [x] Has the code been formatted for consistency and readability?
~~- [ ] Did you also update related documentation and tooling, such as .readme or tests?~~

# Overview
<!--Provide a summary  of this pr. Is this a new module? A new feature? a bug fix? a code reformat?-->
ARM systems (e.g. my macbook) can't build `linux/x86_64` images.

# Context
<!--Provide a URL to a Jira, Pivotal Tracker story, or Assembla ticket. If those are not appropriate, provide the requirements this PR addresses.-->
Pair PR where `PLATFORM` gets set https://github.com/vanderbilt-redcap/redcap_cypress_docker/pull/53

This could have been done via an overriding `docker-compose.arm64.yml` or an additional patch file, but the env along with a sane default felt easier.

# Screenshots
<!--Include screenshots of new pages or features to help other developers understand the features and markup.-->


---
~~Putting this in draft mod until I actually get cypress running on my work machine!~~. 
428615f allows the `app` image to build, but spinning up results in `Error response from daemon: no such image: localhost/redcap_docker-app:latest: image not known`

This appears to be one of the few schisms with `podman`, commenting out the `platform` setting entirely allows `docker compose up -d` to actually complete.

Tangentially, although I've got builds working, I'm running into permission issues that I believe are specific to `podman` (and perhaps also specific to macOS) that I might alter in this PR if they don't affect regular use.

```
app-1  | chown: changing ownership of '/proc/self/fd/1': Permission denied
app-1  | chown: changing ownership of '/proc/self/fd/2': Permission denied
app-1  | (13)Permission denied: AH00072: make_sock: could not bind to address [::]:80
app-1  | (13)Permission denied: AH00072: make_sock: could not bind to address 0.0.0.0:80
```